### PR TITLE
fixed a typo in module declaration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gituhb.com/Bios-Marcel/stasi-blog
+module github.com/Bios-Marcel/stasi-blog
 
 go 1.16
 


### PR DESCRIPTION
Just fixed a typo in the `go.mod` file. I was trying to install stasi-blog by running `go get github.com/Bios-Marcel/stasi-blog` when I came across with this typo. Though, if you would like, I can submit another PR adding instructions of how to install stasi-blog the `go get` opposed to `git clone` and then building (it's easier and executable gets accessible globally).